### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/__phpbrew_update_path.fish
+++ b/functions/__phpbrew_update_path.fish
@@ -3,7 +3,7 @@ function __phpbrew_update_path
   # Strip old phpbrew paths from the path.
   set -gx PATH (for p in $PATH
     echo "$p"
-  end | grep -v "^$PHPBREW_ROOT")
+  end | grep -v "2> $PHPBREW_ROOT")
 
   test -d $PHPBREW_HOME
     or mkdir -p $PHPBREW_HOME


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618